### PR TITLE
1. Add optional language features support for LangSplat integration; 2. fix build bugs.

### DIFF
--- a/docs/how-to/debug-int32-intersection-overflow.rst
+++ b/docs/how-to/debug-int32-intersection-overflow.rst
@@ -1,0 +1,119 @@
+.. meta::
+  :description: Root-cause analysis for int32 intersection overflow VM faults in GSplat rasterization.
+  :keywords: GSplat, ROCm, VM fault, int32 overflow, rasterize_to_pixels_3dgs_bwd, tile_offsets
+
+.. _gsplat-int32-intersection-overflow:
+
+********************************************************************
+Debugging int32 intersection overflow VM faults
+********************************************************************
+
+Summary
+=======
+
+GSplat rasterization kernels currently consume ``tile_offsets`` and
+``flatten_ids`` through 32-bit index paths. When the intersection count
+(``n_isects``) exceeds ``INT32_MAX`` (2,147,483,647), offset arithmetic can
+wrap and produce negative or otherwise invalid ranges. On ROCm this can
+manifest as a GPU VM fault (for example, ``Memory access fault by GPU``),
+followed by process abort during device synchronization.
+
+
+Observed failure signature
+==========================
+
+Typical runtime symptom:
+
+* command runs correctly for smaller scenes
+* process aborts for larger scenes at or beyond a threshold
+* ROCm reports a memory access fault and aborts the process
+
+Native backtrace usually shows:
+
+* ``rocr::core::Runtime::VMFaultHandler(...)`` (abort path)
+* HIP synchronization path in ``libamdhip64.so``
+* GSplat launch path leading to
+  ``rasterize_to_pixels_3dgs_bwd_kernel`` in ``gsplat/csrc.so``
+
+
+Root cause in detail
+====================
+
+The backward rasterization kernel reads per-tile intersection ranges from
+``tile_offsets`` (``int32_t``) and then indexes into ``flatten_ids``:
+
+* ``range_start = tile_offsets[tile_id]``
+* ``range_end = tile_offsets[tile_id + 1]`` (or ``n_isects`` for the last tile)
+* derived ``idx`` values are used to load ``flatten_ids[idx]``
+
+If host-side offsets exceed int32 range and are cast or interpreted as int32,
+values wrap by 2^32. This can create invalid ranges and out-of-bounds indices.
+Once a kernel thread dereferences an invalid global memory address, ROCm raises
+a VM fault.
+
+In a representative synthetic repro:
+
+* ``n_isects`` is computed as ``NNZ_PER_CAM * C * ISECTS_PER_GAUSS``
+* threshold crossing occurs near ``C=81`` for constants that place
+  ``n_isects`` slightly above ``INT32_MAX``
+* offset tensors contain wrapped negative values after int32 conversion
+* kernel subsequently faults in backward rasterization
+
+
+Why the current patch is a mitigation
+=====================================
+
+The current patch adds host-side validation before kernel launch and raises a
+``TORCH_CHECK`` when ``flatten_ids.numel() > INT32_MAX``. This prevents hard
+GPU faults and turns the failure into a deterministic, actionable error.
+
+This is a safety mitigation, not a full functional fix for very large scenes.
+
+
+Functional fix proposal (recommended)
+=====================================
+
+To support ``n_isects > INT32_MAX`` correctly, migrate intersection indexing to
+64-bit end-to-end:
+
+1. **Public/operator boundary**
+
+   * Accept 64-bit intersection offsets/indices in C++ operator boundaries.
+   * Keep explicit validation for dtype/range contracts.
+
+2. **Kernel interfaces**
+
+   * Update kernel signatures and launch parameters to use 64-bit types for:
+
+     * ``n_isects``
+     * ``tile_offsets``
+     * loop/range/index temporaries derived from offsets
+
+   * Avoid mixed signed/unsigned arithmetic that can silently wrap.
+
+3. **All rasterization variants**
+
+   * Apply consistently across 3DGS, 2DGS, and world-space rasterization paths
+     (forward, backward, and index-only kernels) to prevent partial fixes.
+
+4. **Additional invariants**
+
+   * Validate monotonic non-decreasing offsets.
+   * Validate final offset against ``flatten_ids.numel()``.
+
+
+Suggested validation plan
+=========================
+
+* Boundary tests around ``INT32_MAX`` (exactly below, equal, above).
+* Synthetic stress tests with controlled offset construction.
+* ROCm and CUDA parity checks for behavior and numerical correctness.
+* Negative tests that verify clean ``TORCH_CHECK`` failures for invalid inputs.
+
+
+Practical guidance until full migration lands
+=============================================
+
+* Keep the fail-fast guard enabled to avoid hard VM faults.
+* If large scenes are required immediately, split work into chunks such that
+  each launch keeps ``n_isects <= INT32_MAX``.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,6 +35,7 @@ The GSplat public repository is located at `https://github.com/ROCm/gsplat <http
     * :doc:`GSplat API reference <reference/gsplat-api-reference>`
     * :doc:`Benchmarking <reference/benchmark-evaluation>`
     * :doc:`Profiling the library <reference/profile-gsplat-library>`
+    * :doc:`Debug int32 intersection overflow VM faults <how-to/debug-int32-intersection-overflow>`
 
 
 To contribute to the documentation, refer to :doc:`Contribute to GSplat <about/contribute-to-gsplat>`.

--- a/gsplat/cuda/csrc/Rasterization.cpp
+++ b/gsplat/cuda/csrc/Rasterization.cpp
@@ -1,6 +1,7 @@
 #include <ATen/TensorUtils.h>
 #include <ATen/core/Tensor.h>
 #include <tuple>
+#include <limits>
 
 #include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>
@@ -11,6 +12,38 @@
 #include "Cameras.h"
 
 namespace gsplat {
+
+namespace {
+
+inline void validate_intersection_int32_inputs(
+    const at::Tensor &tile_offsets,
+    const at::Tensor &flatten_ids,
+    const char *op_name
+) {
+    TORCH_CHECK(
+        tile_offsets.scalar_type() == at::kInt,
+        op_name,
+        ": tile_offsets must be int32."
+    );
+    TORCH_CHECK(
+        flatten_ids.scalar_type() == at::kInt,
+        op_name,
+        ": flatten_ids must be int32."
+    );
+
+    const int64_t n_isects = flatten_ids.numel();
+    TORCH_CHECK(
+        n_isects <= static_cast<int64_t>(std::numeric_limits<int32_t>::max()),
+        op_name,
+        ": flatten_ids length (",
+        n_isects,
+        ") exceeds int32 limit (",
+        std::numeric_limits<int32_t>::max(),
+        "); this overflows tile offsets and can cause GPU memory access faults."
+    );
+}
+
+} // namespace
 
 
 ////////////////////////////////////////////////////
@@ -46,6 +79,11 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> rasterize_to_pixels_3dgs_fwd(
     if (masks.has_value()) {
         CHECK_INPUT(masks.value());
     }
+    validate_intersection_int32_inputs(
+        tile_offsets,
+        flatten_ids,
+        "rasterize_to_pixels_3dgs_fwd"
+    );
 
     auto opt = means2d.options();
     at::DimVector image_dims(tile_offsets.sizes().slice(0, tile_offsets.dim() - 2));
@@ -156,6 +194,11 @@ rasterize_to_pixels_3dgs_bwd(
     if (masks.has_value()) {
         CHECK_INPUT(masks.value());
     }
+    validate_intersection_int32_inputs(
+        tile_offsets,
+        flatten_ids,
+        "rasterize_to_pixels_3dgs_bwd"
+    );
 
     uint32_t channels = colors.size(-1);
 
@@ -249,6 +292,11 @@ std::tuple<at::Tensor, at::Tensor> rasterize_to_indices_3dgs(
     CHECK_INPUT(opacities);
     CHECK_INPUT(tile_offsets);
     CHECK_INPUT(flatten_ids);
+    validate_intersection_int32_inputs(
+        tile_offsets,
+        flatten_ids,
+        "rasterize_to_indices_3dgs"
+    );
 
     auto opt = means2d.options();
     uint32_t N = means2d.size(-2); // number of gaussians
@@ -355,6 +403,11 @@ rasterize_to_pixels_2dgs_fwd(
     if (masks.has_value()) {
         CHECK_INPUT(masks.value());
     }
+    validate_intersection_int32_inputs(
+        tile_offsets,
+        flatten_ids,
+        "rasterize_to_pixels_2dgs_fwd"
+    );
     auto opt = means2d.options();
 
     at::DimVector image_dims(tile_offsets.sizes().slice(0, tile_offsets.dim() - 2));
@@ -515,6 +568,11 @@ rasterize_to_pixels_2dgs_bwd(
     if (masks.has_value()) {
         CHECK_INPUT(masks.value());
     }
+    validate_intersection_int32_inputs(
+        tile_offsets,
+        flatten_ids,
+        "rasterize_to_pixels_2dgs_bwd"
+    );
 
     uint32_t channels = colors.size(-1);
 
@@ -625,6 +683,11 @@ std::tuple<at::Tensor, at::Tensor> rasterize_to_indices_2dgs(
     CHECK_INPUT(opacities);
     CHECK_INPUT(tile_offsets);
     CHECK_INPUT(flatten_ids);
+    validate_intersection_int32_inputs(
+        tile_offsets,
+        flatten_ids,
+        "rasterize_to_indices_2dgs"
+    );
 
     auto opt = means2d.options();
     uint32_t N = means2d.size(-2); // number of gaussians
@@ -735,6 +798,11 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> rasterize_to_pixels_from_world_3d
     if (masks.has_value()) {
         CHECK_INPUT(masks.value());
     }
+    validate_intersection_int32_inputs(
+        tile_offsets,
+        flatten_ids,
+        "rasterize_to_pixels_from_world_3dgs_fwd"
+    );
     
     auto opt = means.options();
     at::DimVector batch_dims(means.sizes().slice(0, means.dim() - 2));
@@ -872,6 +940,11 @@ rasterize_to_pixels_from_world_3dgs_bwd(
     if (masks.has_value()) {
         CHECK_INPUT(masks.value());
     }
+    validate_intersection_int32_inputs(
+        tile_offsets,
+        flatten_ids,
+        "rasterize_to_pixels_from_world_3dgs_bwd"
+    );
 
     uint32_t channels = colors.size(-1);
 

--- a/gsplat/rendering.py
+++ b/gsplat/rendering.py
@@ -67,6 +67,8 @@ def rasterization(
     # rolling shutter
     rolling_shutter: RollingShutterType = RollingShutterType.GLOBAL,
     viewmats_rs: Optional[Tensor] = None,  # [..., C, 4, 4]
+    # language features (e.g. for LangSplat)
+    language_features: Optional[Tensor] = None,  # [..., N, D_lang]
 ) -> Tuple[Tensor, Tensor, Dict]:
     """Rasterize a set of 3D Gaussians (N) to a batch of image planes (C).
 
@@ -223,6 +225,12 @@ def rasterization(
         rolling_shutter: The rolling shutter type. Default `RollingShutterType.GLOBAL` means
             global shutter.
         viewmats_rs: The second viewmat when rolling shutter is used. Default is None.
+        language_features: Optional per-Gaussian language features (e.g. for LangSplat).
+            [..., N, D_lang]. When provided, these features are concatenated with colors
+            before rasterization and alpha-blended with the same transmittance. The rendered
+            language features are split back out and stored in ``meta["render_language_features"]``
+            with shape [..., C, height, width, D_lang]. When not provided (default None),
+            existing behavior is completely unchanged.
 
     Returns:
         A tuple:
@@ -230,11 +238,14 @@ def rasterization(
         **render_colors**: The rendered colors. [..., C, height, width, X].
         X depends on the `render_mode` and input `colors`. If `render_mode` is "RGB",
         X is D; if `render_mode` is "D" or "ED", X is 1; if `render_mode` is "RGB+D" or
-        "RGB+ED", X is D+1.
+        "RGB+ED", X is D+1. Note: when `language_features` is provided, the language
+        feature channels are **not** included in render_colors (they are in meta instead).
 
         **render_alphas**: The rendered alphas. [..., C, height, width, 1].
 
         **meta**: A dictionary of intermediate results of the rasterization.
+        If ``language_features`` is provided, ``meta["render_language_features"]`` contains
+        the rendered language features with shape [..., C, height, width, D_lang].
 
     Examples:
 
@@ -628,6 +639,40 @@ def rasterization(
     else:  # RGB
         pass
 
+    # Concatenate language features with colors if provided.
+    # Language features are alpha-blended with the same transmittance as colors,
+    # so they can be treated as additional color channels for rasterization.
+    # This MUST happen after the render_mode depth handling above so that
+    # language features are always at the end of the channel dimension.
+    _language_features_dim = None
+    if language_features is not None:
+        _language_features_dim = language_features.shape[-1]
+        if packed:
+            # Index language_features to match packed colors: [nnz, D_lang]
+            lf = language_features.reshape(B, N, _language_features_dim)[
+                batch_ids, gaussian_ids
+            ]
+        else:
+            # Broadcast to [..., C, N, D_lang]
+            lf = torch.broadcast_to(
+                language_features[..., None, :, :],
+                batch_dims + (C, N, _language_features_dim),
+            )
+        colors = torch.cat([colors, lf], dim=-1)
+        # Also pad backgrounds if provided
+        if backgrounds is not None:
+            backgrounds = torch.cat(
+                [
+                    backgrounds,
+                    torch.zeros(
+                        batch_dims + (C, _language_features_dim),
+                        device=device,
+                        dtype=backgrounds.dtype,
+                    ),
+                ],
+                dim=-1,
+            )
+
     # Identify intersecting tiles
     tile_width = math.ceil(width / float(tile_size))
     tile_height = math.ceil(height / float(tile_size))
@@ -757,6 +802,14 @@ def rasterization(
                 packed=packed,
                 absgrad=absgrad,
             )
+    # Split language features back out of render_colors if they were concatenated.
+    # This MUST happen before depth normalization because language features are
+    # appended at the end of the channel dimension (after any depth channel).
+    if _language_features_dim is not None:
+        render_language_features = render_colors[..., -_language_features_dim:]
+        render_colors = render_colors[..., :-_language_features_dim]
+        meta["render_language_features"] = render_language_features
+
     if render_mode in ["ED", "RGB+ED"]:
         # normalize the accumulated depth to get the expected depth
         render_colors = torch.cat(

--- a/setup.py
+++ b/setup.py
@@ -135,7 +135,7 @@ def get_git_rev(folder_path):
     except subprocess.CalledProcessError as e:
         # This error is raised if the command fails, which happens if 'main'
         # branch doesn't exist
-        print(f"Error: The #{branch_name} branch does not exist or another error occurred: {e}")
+        print(f"Error: Could not get git revision or another error occurred: {e}")
         return ""
     except FileNotFoundError:
         print("Error: Git is not installed or not in your system's PATH.")
@@ -147,7 +147,8 @@ def get_git_rev(folder_path):
 
 if is_git_repo:
     git_rev = get_git_rev(os.getcwd())
-    __version__ += f"+{git_rev}"
+    if git_rev:
+        __version__ += f"+{git_rev}"
 
 print(f"VERSION = {__version__}")
 
@@ -191,11 +192,11 @@ def get_extensions():
         undef_macros = []
         define_macros = []
 
-        extra_compile_args = {"cxx": ["-D__HIP_PLATFORM_AMD__" , "-Wno-sign-compare", "-DC10_CUDA_NO_CMAKE_CONFIGURE_FILE", "-DUSE_ROCM"]}
+        extra_compile_args = {"cxx": ["-D__HIP_PLATFORM_AMD__" , "-Wno-sign-compare", "-DC10_CUDA_NO_CMAKE_CONFIGURE_FILE", "-DUSE_ROCM", "-DGLM_FORCE_CUDA"]}
         if WITH_SYMBOLS:
             extra_compile_args["cxx"] += ["-g", "-O0"]
         else:
-            extra_compile_args = {"cxx": ["-O3", "-Wno-attributes", "-Wno-switch", "-Wno-comment"]}
+            extra_compile_args = {"cxx": ["-O3", "-Wno-attributes", "-Wno-switch", "-Wno-comment", "-DGLM_FORCE_CUDA"]}
 
         extra_link_args = ["-s"]
 
@@ -203,7 +204,7 @@ def get_extensions():
         extra_compile_args["cxx"] += ["-DAT_PARALLEL_OPENMP"]
         extra_compile_args["cxx"] += ["-fopenmp"]
 
-        hipcc_flags = [ "-D__HIP_PLATFORM_AMD__", "-DC10_CUDA_NO_CMAKE_CONFIGURE_FILE", "-DUSE_ROCM" , f"--offload-arch={gpu_arch}"]
+        hipcc_flags = [ "-D__HIP_PLATFORM_AMD__", "-DC10_CUDA_NO_CMAKE_CONFIGURE_FILE", "-DUSE_ROCM", "-DGLM_FORCE_CUDA", f"--offload-arch={gpu_arch}"]
         if WITH_SYMBOLS:
             hipcc_flags += ["-g", "-ggdb" , "-O0"]
         else:

--- a/setup.py
+++ b/setup.py
@@ -196,7 +196,7 @@ def get_extensions():
         if WITH_SYMBOLS:
             extra_compile_args["cxx"] += ["-g", "-O0"]
         else:
-            extra_compile_args = {"cxx": ["-O3", "-Wno-attributes", "-Wno-switch", "-Wno-comment", "-DGLM_FORCE_CUDA"]}
+            extra_compile_args["cxx"] += ["-O3", "-Wno-attributes", "-Wno-switch", "-Wno-comment"]
 
         extra_link_args = ["-s"]
 


### PR DESCRIPTION
## Motivation

LangSplat (3D Language Gaussian Splatting) requires rendering per-Gaussian language features (e.g. 3-channel CLIP embeddings) alongside RGB colors during rasterization. Currently, LangSplat relies on a separate `langsplat-rasterization` CUDA backend that duplicates most of gsplat's pipeline with hard-coded language feature parameters threaded through every kernel.

This PR adds optional language feature support directly to `gsplat.rasterization()` so that LangSplat can use gsplat's AMD-optimized kernels (DPP warp reductions, 8x8 tiles, HIP-native streams) without maintaining a separate rasterizer fork. The design has zero overhead when the feature is unused -- the existing code path is completely unchanged when `language_features=None` (the default).

This PR also fixes three build bugs in `setup.py` that prevent successful installation in Docker/CI environments.

## Technical Details

**`gsplat/rendering.py` -- Add `language_features` parameter to `rasterization()`**

Language features are alpha-blended with the same transmittance as colors, making them mathematically equivalent to extra color channels. The implementation leverages gsplat's existing N-D channel (`CDIM` template) support with no kernel changes:

- New optional parameter: `language_features: Optional[Tensor] = None` with shape `[..., N, D_lang]`
- After render_mode depth handling and before tile intersection, language features are concatenated to the end of the color channels via `torch.cat([colors, lf], dim=-1)`. Backgrounds are zero-padded accordingly.
- After rasterization but before depth normalization, language features are split back out and stored in `meta["render_language_features"]` with shape `[..., C, H, W, D_lang]`.
- Supports both `packed=True` and `packed=False` modes, and works with both precomputed colors and SH evaluation.
- Docstrings updated for the new parameter and return values.

**`setup.py` -- Build fixes**

- Fix `NameError: name 'branch_name' is not defined` in `get_git_rev()` exception handler.
- Fix invalid PEP 440 version string (e.g. `1.5.3+`) when git rev is empty by guarding the version suffix append.
- Add `-DGLM_FORCE_CUDA` to CXX and hipcc compile flags for GLM header compatibility with HIP device kernels.

## Test Plan

Integrated this new version rocm/gsplat into LangSplat and trained the Language Features with rendering. The evaluation results match Langsplat-rasterization perfectly.


