### PR TITLE
ROCM 7.2 and RDNA support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,5 @@ data
 results
 
 !examples/benchmarks/compression/results/
+
+gsplat/hip

--- a/gsplat/cuda/csrc/RasterizeToPixels2DGSBwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixels2DGSBwd.cu
@@ -767,7 +767,7 @@ void launch_rasterize_to_pixels_2dgs_bwd_kernel(
     //rocPRIM shared memory allocation
     const uint32_t block_size = tile_size * tile_size;
     const uint32_t warps_per_block =
-        (block_size + 31) / 32;                       // for 64-lane warp
+        (block_size + 31) / 32;                       // for 32-lane wave
     std::size_t warp_scratch_bytes =
         warps_per_block * sizeof(typename rocprim::warp_reduce<float,32>::storage_type);
 

--- a/gsplat/cuda/csrc/RasterizeToPixels2DGSBwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixels2DGSBwd.cu
@@ -179,7 +179,7 @@ __global__ void rasterize_to_pixels_2dgs_bwd_kernel(
     float *normals_batch = &rgbs_batch[block_size * CDIM]; // [block_size * 3]
     
     #if USE_ROCM
-    using warp_reduce_float_t = rocprim::warp_reduce<float,64>;
+    using warp_reduce_float_t = rocprim::warp_reduce<float,32>;
     auto* warp_storage_base   =
     (typename warp_reduce_float_t::storage_type*)
         (normals_batch + block_size * 3);
@@ -246,7 +246,7 @@ __global__ void rasterize_to_pixels_2dgs_bwd_kernel(
     const uint32_t tr = block.thread_rank();
     
     #if USE_ROCM
-    cg::thread_block_tile<64> warp = cg::tiled_partition<64>(block);
+    cg::thread_block_tile<32> warp = cg::tiled_partition<32>(block);
     #else
     cg::thread_block_tile<32> warp = cg::tiled_partition<32>(block);
     #endif
@@ -634,16 +634,16 @@ __global__ void rasterize_to_pixels_2dgs_bwd_kernel(
              * ==================================================
              */
             #if USE_ROCM
-            rocprim_warpSum<CDIM, 64>(v_rgb_local, warp_storage_base);   // CDIM-sized float array
-            rocprim_warpSum<3, 64>(v_normal_local, warp_storage_base);   // 3-sized float array
-            rocprim_warpSum<64>(v_xy_local, warp_storage_base);          // vec2
-            rocprim_warpSum<64>(v_u_M_local, warp_storage_base);         // float
-            rocprim_warpSum<64>(v_v_M_local, warp_storage_base);         // float
-            rocprim_warpSum<64>(v_w_M_local, warp_storage_base);         // float
+            rocprim_warpSum<CDIM, 32>(v_rgb_local, warp_storage_base);   // CDIM-sized float array
+            rocprim_warpSum<3, 32>(v_normal_local, warp_storage_base);   // 3-sized float array
+            rocprim_warpSum<32>(v_xy_local, warp_storage_base);          // vec2
+            rocprim_warpSum<32>(v_u_M_local, warp_storage_base);         // float
+            rocprim_warpSum<32>(v_v_M_local, warp_storage_base);         // float
+            rocprim_warpSum<32>(v_w_M_local, warp_storage_base);         // float
             if (v_means2d_abs != nullptr) {
-                rocprim_warpSum<64>(v_xy_abs_local, warp_storage_base);  // vec2
+                rocprim_warpSum<32>(v_xy_abs_local, warp_storage_base);  // vec2
             }
-            rocprim_warpSum<64>(v_opacity_local, warp_storage_base);     // float
+            rocprim_warpSum<32>(v_opacity_local, warp_storage_base);     // float
             #else
             warpSum<CDIM>(v_rgb_local, warp);
             warpSum<3>(v_normal_local, warp);
@@ -767,9 +767,9 @@ void launch_rasterize_to_pixels_2dgs_bwd_kernel(
     //rocPRIM shared memory allocation
     const uint32_t block_size = tile_size * tile_size;
     const uint32_t warps_per_block =
-        (block_size + 63) / 64;                       // for 64-lane warp
+        (block_size + 31) / 32;                       // for 64-lane warp
     std::size_t warp_scratch_bytes =
-        warps_per_block * sizeof(typename rocprim::warp_reduce<float,64>::storage_type);
+        warps_per_block * sizeof(typename rocprim::warp_reduce<float,32>::storage_type);
 
     int64_t shmem_size =
         tile_size * tile_size *

--- a/gsplat/cuda/csrc/RasterizeToPixels3DGSBwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixels3DGSBwd.cu
@@ -27,7 +27,7 @@ __device__ void dpp_sclr_warpSum(T &val) {
 	// tmp = tmp + __builtin_amdgcn_mov_dpp(tmp, 0x142, 0xf, 0xf, 1); //BCAST15
 	// tmp = tmp + __builtin_amdgcn_mov_dpp(tmp, 0x143, 0xf, 0xf, 1); //BCAST31
 	// val = __shfl(tmp, 63);
-    rocprim_warpSum<64>(val, NULL);
+    rocprim_warpSum<32>(val, NULL);
 }
 
 // This version does reduce but stores the result to a specific location (n_val) on a given lane (ln)
@@ -44,7 +44,7 @@ __device__ void dpp_sprd_warpSum(T &val, int ln, T &n_val) {
 	// if (cg::this_thread_block().thread_rank() == ln)
 	//        n_val = tmp;
     T tmp = val;
-    rocprim_warpSum<64>(tmp, NULL);
+    rocprim_warpSum<32>(tmp, NULL);
     if (cg::this_thread_block().thread_rank() == ln)
         n_val = tmp;
 }
@@ -82,8 +82,8 @@ __device__ T dpp_warpMax(T &val) {
 	// tmp = max(tmp, __builtin_amdgcn_mov_dpp(tmp, 0x142, 0xf, 0xf, 1)); //BCAST15
 	// tmp = max(tmp, __builtin_amdgcn_mov_dpp(tmp, 0x143, 0xf, 0xf, 1)); //BCAST31
 	// return __shfl(tmp, 63);
-    __shared__ typename rocprim::warp_reduce<int32_t, 64>::storage_type warp_storage;
-    rocprim::warp_reduce<int32_t, 64> wreduce;
+    __shared__ typename rocprim::warp_reduce<int32_t, 32>::storage_type warp_storage;
+    rocprim::warp_reduce<int32_t, 32> wreduce;
     int32_t max;
     wreduce.reduce(val,            // 1) value held by this lane
             max,               // 2) reference that will receive the result
@@ -207,7 +207,7 @@ __global__ void rasterize_bs64_to_pixels_3dgs_bwd_kernel(
     // each thread loads one gaussian at a time before rasterizing
     const uint32_t tr = block.thread_rank();
 
-    cg::thread_block_tile<64> warp = cg::tiled_partition<64>(block);
+    cg::thread_block_tile<32> warp = cg::tiled_partition<32>(block);
 
     int32_t warp_bin_final =
     dpp_warpMax(bin_final);
@@ -473,7 +473,7 @@ __global__ void rasterize_to_pixels_3dgs_bwd_kernel(
         (float *)&conic_batch[batch_allocation_size]; // [batch_allocation_size * CDIM]
     
     #if USE_ROCM
-    using warp_reduce_float_t = rocprim::warp_reduce<float,64>;
+    using warp_reduce_float_t = rocprim::warp_reduce<float,32>;
     auto* warp_storage_base   =
     (typename warp_reduce_float_t::storage_type*)
         (rgbs_batch + batch_allocation_size * CDIM);
@@ -500,14 +500,14 @@ __global__ void rasterize_to_pixels_3dgs_bwd_kernel(
     const uint32_t tr = block.thread_rank();
     
     #if USE_ROCM
-    cg::thread_block_tile<64> warp = cg::tiled_partition<64>(block);
+    cg::thread_block_tile<32> warp = cg::tiled_partition<32>(block);
     #else
     cg::thread_block_tile<32> warp = cg::tiled_partition<32>(block);
     #endif
     
     #if USE_ROCM
-        __shared__ typename rocprim::warp_reduce<int32_t, 64>::storage_type warp_storage;
-        rocprim::warp_reduce<int32_t, 64> wreduce;
+        __shared__ typename rocprim::warp_reduce<int32_t, 32>::storage_type warp_storage;
+        rocprim::warp_reduce<int32_t, 32> wreduce;
         int32_t warp_bin_final;
         wreduce.reduce( bin_final,            // 1) value held by this lane
                 warp_bin_final,               // 2) reference that will receive the result
@@ -644,12 +644,12 @@ __global__ void rasterize_to_pixels_3dgs_bwd_kernel(
                 }
             }
             #if USE_ROCM
-            rocprim_warpSum<CDIM, 64>(v_rgb_local, warp_storage_base);   // CDIM-sized float array
-            rocprim_warpSum<64>(v_conic_local, warp_storage_base); // float
-            rocprim_warpSum<64>(v_xy_local, warp_storage_base);    // vec2
+            rocprim_warpSum<CDIM, 32>(v_rgb_local, warp_storage_base);   // CDIM-sized float array
+            rocprim_warpSum<32>(v_conic_local, warp_storage_base); // float
+            rocprim_warpSum<32>(v_xy_local, warp_storage_base);    // vec2
             if (v_means2d_abs != nullptr)
-                rocprim_warpSum<64>(v_xy_abs_local, warp_storage_base);// vec2
-            rocprim_warpSum<64>(v_opacity_local, warp_storage_base);// float
+                rocprim_warpSum<32>(v_xy_abs_local, warp_storage_base);// vec2
+            rocprim_warpSum<32>(v_opacity_local, warp_storage_base);// float
             if (warp.thread_rank() == 0) {
                 int32_t g = id_batch[t]; // flatten index in [I * N] or [nnz]
                 float *v_rgb_ptr = (float *)(v_colors) + CDIM * g;
@@ -776,9 +776,9 @@ void launch_rasterize_to_pixels_3dgs_bwd_kernel(
       if (CDIM <= 16) {
         max_batch_size = block_size;
       }
-      const uint32_t warps_per_block = (block_size + 63) / 64; // for 64-lane warp
+      const uint32_t warps_per_block = (block_size + 31) / 32; // for 64-lane warp
       std::size_t warp_scratch_bytes =
-        warps_per_block * sizeof(typename rocprim::warp_reduce<float,64>::storage_type);
+        warps_per_block * sizeof(typename rocprim::warp_reduce<float,32>::storage_type);
       shmem_size =
         max_batch_size *
         (sizeof(int32_t) + sizeof(vec3) + sizeof(vec3) + sizeof(float) * CDIM) + warp_scratch_bytes;

--- a/gsplat/cuda/csrc/RasterizeToPixels3DGSBwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixels3DGSBwd.cu
@@ -20,29 +20,13 @@ namespace cg = cooperative_groups;
 #if USE_ROCM
 template <typename T>
 __device__ void dpp_sclr_warpSum(T &val) {
-	// T tmp = val + __builtin_amdgcn_mov_dpp(val, 0x118, 0xf, 0xf, 1); //ROW_SHR8
-	// tmp = tmp + __builtin_amdgcn_mov_dpp(tmp, 0x114, 0xf, 0xf, 1); //ROW_SHR4
-	// tmp = tmp + __builtin_amdgcn_mov_dpp(tmp, 0x112, 0xf, 0xf, 1); //ROW_SHR2
-	// tmp = tmp + __builtin_amdgcn_mov_dpp(tmp, 0x111, 0xf, 0xf, 1); //ROW_SHR1
-	// tmp = tmp + __builtin_amdgcn_mov_dpp(tmp, 0x142, 0xf, 0xf, 1); //BCAST15
-	// tmp = tmp + __builtin_amdgcn_mov_dpp(tmp, 0x143, 0xf, 0xf, 1); //BCAST31
-	// val = __shfl(tmp, 63);
     rocprim_warpSum<32>(val, NULL);
 }
 
 // This version does reduce but stores the result to a specific location (n_val) on a given lane (ln)
-// It can be sued to generate results than can be stored wave-coalesed.
+// It can be used to generate results than can be stored wave-coalesced.
 template <typename T>
 __device__ void dpp_sprd_warpSum(T &val, int ln, T &n_val) {
-	// T tmp = val + __builtin_amdgcn_mov_dpp(val, 0x118, 0xf, 0xf, 1); //ROW_SHR8
-	// tmp = tmp + __builtin_amdgcn_mov_dpp(tmp, 0x114, 0xf, 0xf, 1); //ROW_SHR4
-	// tmp = tmp + __builtin_amdgcn_mov_dpp(tmp, 0x112, 0xf, 0xf, 1); //ROW_SHR2
-	// tmp = tmp + __builtin_amdgcn_mov_dpp(tmp, 0x111, 0xf, 0xf, 1); //ROW_SHR1
-	// tmp = tmp + __builtin_amdgcn_mov_dpp(tmp, 0x142, 0xf, 0xf, 1); //BCAST15
-	// tmp = tmp + __builtin_amdgcn_mov_dpp(tmp, 0x143, 0xf, 0xf, 1); //BCAST31
-	// tmp = __shfl(tmp, 63);
-	// if (cg::this_thread_block().thread_rank() == ln)
-	//        n_val = tmp;
     T tmp = val;
     rocprim_warpSum<32>(tmp, NULL);
     if (cg::this_thread_block().thread_rank() == ln)
@@ -54,7 +38,7 @@ template <uint32_t numel, typename T>
 __device__ void dpp_vec_warpSum(T &val) {
           #pragma unroll
           for (int e=0; e<numel; e++)
-            dpp_sprd_warpSum(val[e], e%64, val[e/64]);
+            dpp_sprd_warpSum(val[e], e%32, val[e/32]);
 }
 
 template <typename T>
@@ -74,22 +58,24 @@ __device__ void dpp_warpSum(T &val) {
 
 template <typename T>
 __device__ T dpp_warpMax(T &val) {
-	// using ncT = typename std::remove_const<T>::type;
-	// ncT tmp = max(val, __builtin_amdgcn_mov_dpp(val, 0x118, 0xf, 0xf, 1)); //ROW_SHR8
-	// tmp = max(tmp, __builtin_amdgcn_mov_dpp(tmp, 0x114, 0xf, 0xf, 1)); //ROW_SHR4
-	// tmp = max(tmp, __builtin_amdgcn_mov_dpp(tmp, 0x112, 0xf, 0xf, 1)); //ROW_SHR2
-	// tmp = max(tmp, __builtin_amdgcn_mov_dpp(tmp, 0x111, 0xf, 0xf, 1)); //ROW_SHR1
-	// tmp = max(tmp, __builtin_amdgcn_mov_dpp(tmp, 0x142, 0xf, 0xf, 1)); //BCAST15
-	// tmp = max(tmp, __builtin_amdgcn_mov_dpp(tmp, 0x143, 0xf, 0xf, 1)); //BCAST31
-	// return __shfl(tmp, 63);
-    __shared__ typename rocprim::warp_reduce<int32_t, 32>::storage_type warp_storage;
+    __shared__ typename rocprim::warp_reduce<int32_t, 32>::storage_type warp_storage[2];
+    const int warp_id = (threadIdx.x + threadIdx.y * blockDim.x) / 32;
     rocprim::warp_reduce<int32_t, 32> wreduce;
     int32_t max;
     wreduce.reduce(val,            // 1) value held by this lane
             max,               // 2) reference that will receive the result
-            warp_storage,                 // 3) shared-memory storage
+            warp_storage[warp_id],       // 3) shared-memory storage
             rocprim::maximum<int32_t>());
-    return max;
+    // Cross-warp max reduction: each warp leader has its partial max,
+    // do a second reduction via shared memory.
+    // For a 64-thread block with 2 warps, the leader of each warp writes
+    // its result, then we do a final max.
+    __shared__ int32_t partial_max[2];
+    if (cg::tiled_partition<32>(cg::this_thread_block()).thread_rank() == 0) {
+        partial_max[warp_id] = max;
+    }
+    cg::this_thread_block().sync();
+    return ::max(partial_max[0], partial_max[1]);
 }
 
 template <uint32_t CDIM, typename scalar_t>
@@ -185,7 +171,7 @@ __global__ void rasterize_bs64_to_pixels_3dgs_bwd_kernel(
     vec3 *conic_batch =
         reinterpret_cast<vec3 *>(&xy_opacity_batch[batch_allocation_size]); // [batch_allocation_size]
     float *rgbs_batch =
-        (float *)s; // [batch_allocation_size * CDIM]
+        (float *)&conic_batch[batch_allocation_size]; // [batch_allocation_size * CDIM]
 
     // this is the T AFTER the last gaussian in this pixel
     float T_final = 1.0f - render_alphas[pix_id];
@@ -211,9 +197,6 @@ __global__ void rasterize_bs64_to_pixels_3dgs_bwd_kernel(
 
     int32_t warp_bin_final =
     dpp_warpMax(bin_final);
-    int32_t _id_batch;
-    vec3 _xy_opacity_batch;
-    vec3 _conic_batch;
     for (uint32_t b = 0; b < num_batches; ++b) {
         // resync all threads before writing next batch of shared mem
         block.sync();
@@ -228,11 +211,11 @@ __global__ void rasterize_bs64_to_pixels_3dgs_bwd_kernel(
         const int32_t idx = batch_end - tr;
         if (tr < current_batch_size && idx >= range_start) {
             int32_t g = flatten_ids[idx]; // flatten index in [I * N] or [nnz]
-            _id_batch = g;
+            id_batch[tr] = g;
             const vec2 xy = means2d[g];
             const float opac = opacities[g];
-            _xy_opacity_batch = {xy.x, xy.y, opac};
-            _conic_batch = conics[g];
+            xy_opacity_batch[tr] = {xy.x, xy.y, opac};
+            conic_batch[tr] = conics[g];
 #pragma unroll
             for (uint32_t k = 0; k < CDIM; ++k) {
                 rgbs_batch[tr * CDIM + k] = colors[g * CDIM + k];
@@ -252,13 +235,13 @@ __global__ void rasterize_bs64_to_pixels_3dgs_bwd_kernel(
             vec2 delta;
             vec3 conic;
             float vis;
-            conic.x = __shfl(_conic_batch.x, t);
-            conic.y = __shfl(_conic_batch.y, t);
-            conic.z = __shfl(_conic_batch.z, t);
-            vec3 xy_opac;
-            xy_opac.x = __shfl(_xy_opacity_batch.x, t);
-            xy_opac.y = __shfl(_xy_opacity_batch.y, t);
-            xy_opac.z = __shfl(_xy_opacity_batch.z, t);
+            // Use shared memory arrays for data sharing instead of __shfl.
+            // With wave32 and a 64-thread block, bare __shfl only reaches
+            // threads within the same 32-lane wavefront, so threads in
+            // different waves would read different data for the same index t.
+            // Shared memory is visible to all threads in the block.
+            conic = conic_batch[t];
+            vec3 xy_opac = xy_opacity_batch[t];
             if (valid) {
                 opac = xy_opac.z;
                 delta = {xy_opac.x - px, xy_opac.y - py};
@@ -339,13 +322,13 @@ __global__ void rasterize_bs64_to_pixels_3dgs_bwd_kernel(
             if (v_means2d_abs != nullptr)
                 dpp_warpSum(v_xy_abs_local);// vec2
             dpp_warpSum(v_opacity_local);// float
-	    int32_t g = __shfl(_id_batch, t); // flatten index in [I * N] or [nnz]
+            int32_t g = id_batch[t]; // flatten index in [I * N] or [nnz] - read from shared mem
 
             float *v_rgb_ptr = (float *)(v_colors) + CDIM * g;
 #pragma unroll
-            for (uint32_t k = 0; k < CDIM; k+=64) {
-		if (k + warp.thread_rank() < CDIM)
-                    atomicAdd(v_rgb_ptr + k + warp.thread_rank(), v_rgb_local[k/64]);
+            for (uint32_t k = 0; k < CDIM; k+=32) {
+                if (k + warp.thread_rank() < CDIM)
+                    atomicAdd(v_rgb_ptr + k + warp.thread_rank(), v_rgb_local[k/32]);
             }
 
             if (warp.thread_rank() == 0) {
@@ -506,13 +489,25 @@ __global__ void rasterize_to_pixels_3dgs_bwd_kernel(
     #endif
     
     #if USE_ROCM
-        __shared__ typename rocprim::warp_reduce<int32_t, 32>::storage_type warp_storage;
+        const int n_warps = (block_size + 31) / 32;
+        __shared__ typename rocprim::warp_reduce<int32_t, 32>::storage_type warp_max_storage[8]; // max 8 warps for 256-thread block
         rocprim::warp_reduce<int32_t, 32> wreduce;
-        int32_t warp_bin_final;
+        const int warp_id = tr / 32;
+        int32_t warp_bin_final_local;
         wreduce.reduce( bin_final,            // 1) value held by this lane
-                warp_bin_final,               // 2) reference that will receive the result
-                warp_storage,                 // 3) shared-memory storage
+                warp_bin_final_local,          // 2) reference that will receive the result
+                warp_max_storage[warp_id],    // 3) shared-memory storage
                 rocprim::maximum<int32_t>()); // 4) binary operator
+        // Cross-warp reduction for warp_bin_final
+        __shared__ int32_t partial_bin_max[8];
+        if (warp.thread_rank() == 0) {
+            partial_bin_max[warp_id] = warp_bin_final_local;
+        }
+        block.sync();
+        int32_t warp_bin_final = 0;
+        for (int w = 0; w < n_warps; w++) {
+            warp_bin_final = max(warp_bin_final, partial_bin_max[w]);
+        }
     #else
     const int32_t warp_bin_final =
         cg::reduce(warp, bin_final, cg::greater<int>());
@@ -761,7 +756,7 @@ void launch_rasterize_to_pixels_3dgs_bwd_kernel(
     const uint32_t block_size = tile_size * tile_size;
     uint32_t max_batch_size;
     int64_t shmem_size;
-    if (block_size == 64) { // wave64-optimized path
+    if (block_size == 64) { // wave32-compatible path for tile_size=8
       max_batch_size = 32;
       //max_batch_size = min(max_batch_size, block_size);
       if (CDIM <= 32) {
@@ -769,14 +764,14 @@ void launch_rasterize_to_pixels_3dgs_bwd_kernel(
       }
       shmem_size =
         max_batch_size *
-        (sizeof(float) * CDIM);
+        (sizeof(int32_t) + sizeof(vec3) + sizeof(vec3) + sizeof(float) * CDIM);
     } else {
       max_batch_size = 16;
       max_batch_size = min(max_batch_size, block_size);
       if (CDIM <= 16) {
         max_batch_size = block_size;
       }
-      const uint32_t warps_per_block = (block_size + 31) / 32; // for 64-lane warp
+      const uint32_t warps_per_block = (block_size + 31) / 32; // for 32-lane wave
       std::size_t warp_scratch_bytes =
         warps_per_block * sizeof(typename rocprim::warp_reduce<float,32>::storage_type);
       shmem_size =

--- a/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSBwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSBwd.cu
@@ -482,7 +482,7 @@ void launch_rasterize_to_pixels_from_world_3dgs_bwd_kernel(
     //rocPRIM shared memory allocation
     const uint32_t block_size = tile_size * tile_size;
     const uint32_t warps_per_block =
-        (block_size + 31) / 32;                       // for 64-lane warp
+        (block_size + 31) / 32;                       // for 32-lane wave
     std::size_t warp_scratch_bytes =
         warps_per_block * sizeof(typename rocprim::warp_reduce<float,32>::storage_type);
 

--- a/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSBwd.cu
+++ b/gsplat/cuda/csrc/RasterizeToPixelsFromWorld3DGSBwd.cu
@@ -190,7 +190,7 @@ __global__ void rasterize_to_pixels_from_world_3dgs_bwd_kernel(
         (float *)&quat_batch[block_size]; // [block_size * CDIM]
         
     #if USE_ROCM
-    using warp_reduce_float_t = rocprim::warp_reduce<float,64>;
+    using warp_reduce_float_t = rocprim::warp_reduce<float,32>;
     auto* warp_storage_base   =
     (typename warp_reduce_float_t::storage_type*)
         (rgbs_batch + block_size * CDIM);
@@ -216,7 +216,7 @@ __global__ void rasterize_to_pixels_from_world_3dgs_bwd_kernel(
     // each thread loads one gaussian at a time before rasterizing
     const uint32_t tr = block.thread_rank();
     #if USE_ROCM
-    cg::thread_block_tile<64> warp = cg::tiled_partition<64>(block);
+    cg::thread_block_tile<32> warp = cg::tiled_partition<32>(block);
     #else
     cg::thread_block_tile<32> warp = cg::tiled_partition<32>(block);
     #endif
@@ -376,11 +376,11 @@ __global__ void rasterize_to_pixels_from_world_3dgs_bwd_kernel(
                 }
             }
             #if USE_ROCM
-            rocprim_warpSum<CDIM, 64>(v_rgb_local, warp_storage_base);   // CDIM-sized float array
-            rocprim_warpSum<64>(v_mean_local, warp_storage_base);        // vec3
-            rocprim_warpSum<64>(v_scale_local, warp_storage_base);       // vec3
-            rocprim_warpSum<64>(v_quat_local, warp_storage_base);        // vec4
-            rocprim_warpSum<64>(v_opacity_local, warp_storage_base);     // float
+            rocprim_warpSum<CDIM, 32>(v_rgb_local, warp_storage_base);   // CDIM-sized float array
+            rocprim_warpSum<32>(v_mean_local, warp_storage_base);        // vec3
+            rocprim_warpSum<32>(v_scale_local, warp_storage_base);       // vec3
+            rocprim_warpSum<32>(v_quat_local, warp_storage_base);        // vec4
+            rocprim_warpSum<32>(v_opacity_local, warp_storage_base);     // float
             #else
             warpSum<CDIM>(v_rgb_local, warp);
             warpSum(v_mean_local, warp);
@@ -482,9 +482,9 @@ void launch_rasterize_to_pixels_from_world_3dgs_bwd_kernel(
     //rocPRIM shared memory allocation
     const uint32_t block_size = tile_size * tile_size;
     const uint32_t warps_per_block =
-        (block_size + 63) / 64;                       // for 64-lane warp
+        (block_size + 31) / 32;                       // for 64-lane warp
     std::size_t warp_scratch_bytes =
-        warps_per_block * sizeof(typename rocprim::warp_reduce<float,64>::storage_type);
+        warps_per_block * sizeof(typename rocprim::warp_reduce<float,32>::storage_type);
 
     int64_t shmem_size =
         tile_size * tile_size *

--- a/gsplat/cuda/include/Common.cuh
+++ b/gsplat/cuda/include/Common.cuh
@@ -38,7 +38,7 @@ namespace gsplat {
     do {                                                                       \
         size_t temp_storage_bytes = 0;                                         \
         auto res = func(nullptr, temp_storage_bytes, __VA_ARGS__);                        \
-        auto &caching_allocator = *::c10::hip::HIPCachingAllocator::get();   \
+        auto &caching_allocator = *::c10::cuda::CUDACachingAllocator::get();   \
         auto temp_storage = caching_allocator.allocate(temp_storage_bytes);    \
         res = func(temp_storage.get(), temp_storage_bytes, __VA_ARGS__);  \
 	assert(res == hipSuccess);                                            \

--- a/gsplat/cuda/include/Common.h
+++ b/gsplat/cuda/include/Common.h
@@ -11,7 +11,7 @@
 #include <c10/hip/CUDAGuard.h>
 #else
 #include <c10/hip/HIPStream.h> // at::hip::getCurrentHIPStream
-#include <c10/hip/HIPCachingAllocator.h>
+#include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/hip/HIPStream.h>
 #include <c10/hip/HIPGuard.h>
 #include <c10/core/DeviceGuard.h>
@@ -38,7 +38,7 @@ namespace gsplat {
 // handle the temporary storage and 'twice' calls for cub API
 #else
 #define cub hipcub
-#define GET_CURRENT_STREAM() at::hip::getCurrentHIPStream()
+#define GET_CURRENT_STREAM() at::cuda::getCurrentCUDAStream()
 #define DEVICE_GUARD(_ten)
     //const c10::OptionalDeviceGuard device_guard(at::device_of(_ten));                                                   \
     const at::hip::OptionalHIPGuard device_guard(device_of(_ten));

--- a/gsplat/cuda/include/Utils.cuh
+++ b/gsplat/cuda/include/Utils.cuh
@@ -233,7 +233,7 @@ inline __device__ void manual_warpSum(float val[N]) {
     }  
 }
 
-template<int LOGICAL_WARP_SIZE = 64>
+template<int LOGICAL_WARP_SIZE = 32>
 __device__ inline void rocprim_warpSum_scalar(float& val, typename rocprim::warp_reduce<float,LOGICAL_WARP_SIZE>::storage_type*
             warp_storage_base)
 {
@@ -256,7 +256,7 @@ __device__ inline void rocprim_warpSum_scalar(float& val, typename rocprim::warp
 
 //-----------------------------------------------------------------------------
 //  1. float overload  ────────────────────────────────────────────────────────
-template<int LOGICAL_WARP_SIZE = 64>
+template<int LOGICAL_WARP_SIZE = 32>
 __device__ inline void rocprim_warpSum(float& x, typename rocprim::warp_reduce<float,LOGICAL_WARP_SIZE>::storage_type*
                     warp_storage_base)
 {
@@ -265,7 +265,7 @@ __device__ inline void rocprim_warpSum(float& x, typename rocprim::warp_reduce<f
 
 //-----------------------------------------------------------------------------
 //  2. vec2 / vec3 / vec4 overloads  ─────────────────────────────────────────-
-template<int LOGICAL_WARP_SIZE = 64>
+template<int LOGICAL_WARP_SIZE = 32>
 __device__ inline void rocprim_warpSum(vec2& v, typename rocprim::warp_reduce<float,LOGICAL_WARP_SIZE>::storage_type*
                     warp_storage_base)
 {
@@ -273,7 +273,7 @@ __device__ inline void rocprim_warpSum(vec2& v, typename rocprim::warp_reduce<fl
     rocprim_warpSum_scalar<LOGICAL_WARP_SIZE>(v.y, warp_storage_base);
 }
 
-template<int LOGICAL_WARP_SIZE = 64>
+template<int LOGICAL_WARP_SIZE = 32>
 __device__ inline void rocprim_warpSum(vec3& v, typename rocprim::warp_reduce<float,LOGICAL_WARP_SIZE>::storage_type*
                     warp_storage_base)
 {
@@ -282,7 +282,7 @@ __device__ inline void rocprim_warpSum(vec3& v, typename rocprim::warp_reduce<fl
     rocprim_warpSum_scalar<LOGICAL_WARP_SIZE>(v.z, warp_storage_base);
 }
 
-template<int LOGICAL_WARP_SIZE = 64>
+template<int LOGICAL_WARP_SIZE = 32>
 __device__ inline void rocprim_warpSum(vec4& v, typename rocprim::warp_reduce<float,LOGICAL_WARP_SIZE>::storage_type*
                     warp_storage_base)
 {
@@ -294,7 +294,7 @@ __device__ inline void rocprim_warpSum(vec4& v, typename rocprim::warp_reduce<fl
 
 //-----------------------------------------------------------------------------
 //  3. fixed-size float array overload  ───────────────────────────────────────
-template<int N, int LOGICAL_WARP_SIZE = 64>
+template<int N, int LOGICAL_WARP_SIZE = 32>
 __device__ inline void rocprim_warpSum(float (&a)[N], typename rocprim::warp_reduce<float,LOGICAL_WARP_SIZE>::storage_type*
                     warp_storage_base)
 {
@@ -311,7 +311,7 @@ inline __device__ void manual_dynamic_reduce_sum_vec2(
 ) {  
     // First, create a mask of all threads with matching labels  
     unsigned long long my_label_mask = 0;  
-    for (int i = 0; i < 64; ++i) {  
+    for (int i = 0; i < 32; ++i) {  
         if (warp_active_mask & (1ULL << i)) {  
             long long lane_label = __shfl_sync(warp_active_mask, current_label, i);  
             if (lane_label == current_label) {  
@@ -361,7 +361,7 @@ inline __device__ void manual_dynamic_reduce_sum_vec3(
 ) {  
     // First, create a mask of all threads with matching labels  
     unsigned long long my_label_mask = 0;  
-    for (int i = 0; i < 64; ++i) {  
+    for (int i = 0; i < 32; ++i) {  
         if (warp_active_mask & (1ULL << i)) {  
             long long lane_label = __shfl_sync(warp_active_mask, current_label, i);  
             if (lane_label == current_label) {  
@@ -414,7 +414,7 @@ inline __device__ void manual_dynamic_reduce_sum_vec4(
 ) {  
     // First, create a mask of all threads with matching labels  
     unsigned long long my_label_mask = 0;  
-    for (int i = 0; i < 64; ++i) {  
+    for (int i = 0; i < 32; ++i) {  
         if (warp_active_mask & (1ULL << i)) {  
             long long lane_label = __shfl_sync(warp_active_mask, current_label, i);  
             if (lane_label == current_label) {  
@@ -471,7 +471,7 @@ inline __device__ void manual_dynamic_reduce_sum_mat3(
 ) {  
     // First, create a mask of all threads with matching labels  
     unsigned long long my_label_mask = 0;  
-    for (int i = 0; i < 64; ++i) {  
+    for (int i = 0; i < 32; ++i) {  
         if (warp_active_mask & (1ULL << i)) {  
             long long lane_label = __shfl_sync(warp_active_mask, current_label, i);  
             if (lane_label == current_label) {  

--- a/gsplat/cuda/include/Utils.cuh
+++ b/gsplat/cuda/include/Utils.cuh
@@ -233,28 +233,25 @@ inline __device__ void manual_warpSum(float val[N]) {
     }  
 }
 
-// HIP-native warp reduction using shuffle (works on all wavefront sizes including RDNA3 32-wide)
 template<int LOGICAL_WARP_SIZE = 64>
 __device__ inline void rocprim_warpSum_scalar(float& val, typename rocprim::warp_reduce<float,LOGICAL_WARP_SIZE>::storage_type*
             warp_storage_base)
 {
-    unsigned long long warp_mask = __activemask();
-    
-    // Perform warp-level sum using shuffle
-    // Note: LOGICAL_WARP_SIZE reduction with wavefront-sized steps
-    #pragma unroll
-    for (int offset = LOGICAL_WARP_SIZE / 2; offset >= 32; offset /= 2) {
-        float other = __shfl_down_sync(warp_mask, val, offset);
-        val += other;
-    }
-    // Handle remaining reduction within wavefront
-    if (LOGICAL_WARP_SIZE > 32) {
-        float other = __shfl_down_sync(warp_mask, val, 32);
-        val += other;
-    }
-    
-    // Broadcast result from lane 0 to all threads in warp
-    val = __shfl_sync(warp_mask, val, 0);
+    using warp_reduce_t = rocprim::warp_reduce<float, LOGICAL_WARP_SIZE>;
+    //constexpr int NUM_WARPS = BLOCK_SIZE / LOGICAL_WARP_SIZE;
+
+    // One storage object per logical warp inside the block
+    // __shared__ typename warp_reduce_t::storage_type
+    //     warp_storage[NUM_WARPS];
+
+    const int warp_id = threadIdx.x / LOGICAL_WARP_SIZE;
+    warp_reduce_t wreduce;
+    float sum;
+    wreduce.reduce(val,                       
+                   sum,
+                   warp_storage_base[warp_id],    
+                   rocprim::plus<float>());
+    val = sum;
 }
 
 //-----------------------------------------------------------------------------

--- a/gsplat/cuda/include/Utils.cuh
+++ b/gsplat/cuda/include/Utils.cuh
@@ -233,25 +233,28 @@ inline __device__ void manual_warpSum(float val[N]) {
     }  
 }
 
+// HIP-native warp reduction using shuffle (works on all wavefront sizes including RDNA3 32-wide)
 template<int LOGICAL_WARP_SIZE = 64>
 __device__ inline void rocprim_warpSum_scalar(float& val, typename rocprim::warp_reduce<float,LOGICAL_WARP_SIZE>::storage_type*
             warp_storage_base)
 {
-    using warp_reduce_t = rocprim::warp_reduce<float, LOGICAL_WARP_SIZE>;
-    //constexpr int NUM_WARPS = BLOCK_SIZE / LOGICAL_WARP_SIZE;
-
-    // One storage object per logical warp inside the block
-    // __shared__ typename warp_reduce_t::storage_type
-    //     warp_storage[NUM_WARPS];
-
-    const int warp_id = threadIdx.x / LOGICAL_WARP_SIZE;
-    warp_reduce_t wreduce;
-    float sum;
-    wreduce.reduce(val,                       
-                   sum,
-                   warp_storage_base[warp_id],    
-                   rocprim::plus<float>());
-    val = sum;
+    unsigned long long warp_mask = __activemask();
+    
+    // Perform warp-level sum using shuffle
+    // Note: LOGICAL_WARP_SIZE reduction with wavefront-sized steps
+    #pragma unroll
+    for (int offset = LOGICAL_WARP_SIZE / 2; offset >= 32; offset /= 2) {
+        float other = __shfl_down_sync(warp_mask, val, offset);
+        val += other;
+    }
+    // Handle remaining reduction within wavefront
+    if (LOGICAL_WARP_SIZE > 32) {
+        float other = __shfl_down_sync(warp_mask, val, 32);
+        val += other;
+    }
+    
+    // Broadcast result from lane 0 to all threads in warp
+    val = __shfl_sync(warp_mask, val, 0);
 }
 
 //-----------------------------------------------------------------------------

--- a/gsplat/cuda/include/Utils.cuh
+++ b/gsplat/cuda/include/Utils.cuh
@@ -244,7 +244,10 @@ __device__ inline void rocprim_warpSum_scalar(float& val, typename rocprim::warp
     // __shared__ typename warp_reduce_t::storage_type
     //     warp_storage[NUM_WARPS];
 
-    const int warp_id = threadIdx.x / LOGICAL_WARP_SIZE;
+    // Use flat thread ID to correctly index per-warp shared storage.
+    // threadIdx.x alone is wrong for 2D thread blocks (e.g. tile_size=16
+    // gives blockDim=(16,16,1), so threadIdx.x only ranges 0..15).
+    const int warp_id = (threadIdx.x + threadIdx.y * blockDim.x + threadIdx.z * blockDim.x * blockDim.y) / LOGICAL_WARP_SIZE;
     warp_reduce_t wreduce;
     float sum;
     wreduce.reduce(val,                       

--- a/setup.py
+++ b/setup.py
@@ -16,43 +16,43 @@ __version__ = None
 exec(open("gsplat/version.py", "r").read())
 import subprocess
 
-
 def get_rocm_arch():
     """
     Runs rocminfo and extracts the GPU architecture (gfx code).
-
+    
     Returns:
         str: The gfx code (e.g., 'gfx942', 'gfx90a'), or 'gfx942' as fallback.
     """
     try:
         # Run rocminfo command
         result = subprocess.run(
-            ["rocminfo"], capture_output=True, text=True, check=True
+            ['rocminfo'],
+            capture_output=True,
+            text=True,
+            check=True
         )
-
+        
         # Parse the output to find the gfx architecture
         # Look for lines like "Name:                    gfx942"
         output = result.stdout
-
+        
         # Search for gfx code pattern
-        match = re.search(r"Name:\s+(gfx[0-9a-z]+)", output)
+        match = re.search(r'Name:\s+(gfx[0-9a-z]+)', output)
         if match:
             gfx_code = match.group(1)
             print(f"Detected ROCm GPU architecture: {gfx_code}")
             return gfx_code
-
+        
         # Alternative pattern: sometimes it appears as "gfxXXX" directly
-        match = re.search(r"\b(gfx[0-9a-z]+)\b", output)
+        match = re.search(r'\b(gfx[0-9a-z]+)\b', output)
         if match:
             gfx_code = match.group(1)
             print(f"Detected ROCm GPU architecture: {gfx_code}")
             return gfx_code
-
-        print(
-            "Warning: Could not detect GPU architecture from rocminfo, using default gfx942"
-        )
+            
+        print("Warning: Could not detect GPU architecture from rocminfo, using default gfx942")
         return "gfx942"
-
+        
     except subprocess.CalledProcessError as e:
         print(f"Error running rocminfo: {e}")
         print("Using default architecture: gfx942")
@@ -65,7 +65,6 @@ def get_rocm_arch():
         print(f"Unexpected error getting ROCm architecture: {e}")
         print("Using default architecture: gfx942")
         return "gfx942"
-
 
 def is_git_repo(folder_path):
     """
@@ -84,10 +83,10 @@ def is_git_repo(folder_path):
     try:
         # Run the git command
         result = subprocess.run(
-            ["git", "rev-parse", "--git-dir"],
+            ['git', 'rev-parse', '--git-dir'],
             cwd=folder_path,
             capture_output=True,
-            text=True,
+            text=True
         )
 
         # The command returns an exit code of 0 if it's a repo
@@ -101,7 +100,6 @@ def is_git_repo(folder_path):
         # Handle other unexpected errors
         print(f"An unexpected error occurred: {e}")
         return False
-
 
 def get_git_rev(folder_path):
     """
@@ -119,11 +117,15 @@ def get_git_rev(folder_path):
         # Use subprocess to run 'git rev-parse main' to get the commit hash
         # 'rev-parse' is a low-level command used to translate a human-readable
         # name into an SHA-1.
-        command = ["git", "rev-parse", "--short", "HEAD"]
+        command = ['git', 'rev-parse', '--short' ,"HEAD"]
 
         # Run the command in the specified folder
         result = subprocess.run(
-            command, cwd=folder_path, capture_output=True, text=True, check=True
+            command,
+            cwd=folder_path,
+            capture_output=True,
+            text=True,
+            check=True
         )
 
         # The output is the commit hash
@@ -133,9 +135,7 @@ def get_git_rev(folder_path):
     except subprocess.CalledProcessError as e:
         # This error is raised if the command fails, which happens if 'main'
         # branch doesn't exist
-        print(
-            f"Error: The #{branch_name} branch does not exist or another error occurred: {e}"
-        )
+        print(f"Error: The #{branch_name} branch does not exist or another error occurred: {e}")
         return ""
     except FileNotFoundError:
         print("Error: Git is not installed or not in your system's PATH.")
@@ -144,7 +144,6 @@ def get_git_rev(folder_path):
         print(f"An unexpected error occurred: {e}")
         return ""
     return ""
-
 
 if is_git_repo:
     git_rev = get_git_rev(os.getcwd())
@@ -155,7 +154,7 @@ print(f"VERSION = {__version__}")
 URL = "https://github.com/rocm/gsplat"
 
 BUILD_NO_CUDA = os.getenv("BUILD_NO_CUDA", "0") == "1"
-WITH_SYMBOLS = os.getenv("WITH_SYMBOLS", "0") == "1"
+WITH_SYMBOLS =  os.getenv("WITH_SYMBOLS", "0") == "1"
 LINE_INFO = os.getenv("LINE_INFO", "0") == "1"
 
 ENABLE_TEST_COVERAGE = os.getenv("ENABLE_TEST_COVERAGE", "0") == "1"
@@ -167,20 +166,16 @@ if not MAX_JOBS:
     os.environ["MAX_JOBS"] = "10"
     print(f"Setting MAX_JOBS to {os.environ['MAX_JOBS']}")
 
-
 def get_ext():
     from torch.utils.cpp_extension import BuildExtension
-
     return BuildExtension.with_options(no_python_abi_suffix=True, use_ninja=True)
 
 
 def get_extensions():
     if IS_ROCM:
         from torch.utils.cpp_extension import CUDAExtension
-
         print("ROCM detected, compiling with HIP support...")
         from torch.utils.cpp_extension import CppExtension
-
         # Get the GPU architecture dynamically
         gpu_arch = get_rocm_arch()
         print(f"gpu arch is set to {gpu_arch}")
@@ -189,29 +184,18 @@ def get_extensions():
         conda_pip_packages = f"{conda_lib_path}/python3.11/site-packages"
 
         # Use relative path instead of hardcoded absolute path
-        extensions_dir = osp.join("gsplat", "cuda")
-        sources = glob.glob(osp.join(extensions_dir, "csrc", "*.cu")) + glob.glob(
-            osp.join(extensions_dir, "csrc", "*.cpp")
-        )
+        extensions_dir = osp.join("gsplat","cuda")
+        sources = glob.glob(osp.join(extensions_dir, "csrc", "*.cu")) + glob.glob(osp.join(extensions_dir, "csrc", "*.cpp"))
         sources += [osp.join(extensions_dir, "ext.cpp")]
 
         undef_macros = []
         define_macros = []
 
-        extra_compile_args = {
-            "cxx": [
-                "-D__HIP_PLATFORM_AMD__",
-                "-Wno-sign-compare",
-                "-DC10_CUDA_NO_CMAKE_CONFIGURE_FILE",
-                "-DUSE_ROCM",
-            ]
-        }
+        extra_compile_args = {"cxx": ["-D__HIP_PLATFORM_AMD__" , "-Wno-sign-compare", "-DC10_CUDA_NO_CMAKE_CONFIGURE_FILE", "-DUSE_ROCM"]}
         if WITH_SYMBOLS:
             extra_compile_args["cxx"] += ["-g", "-O0"]
         else:
-            extra_compile_args = {
-                "cxx": ["-O3", "-Wno-attributes", "-Wno-switch", "-Wno-comment"]
-            }
+            extra_compile_args = {"cxx": ["-O3", "-Wno-attributes", "-Wno-switch", "-Wno-comment"]}
 
         extra_link_args = ["-s"]
 
@@ -219,20 +203,11 @@ def get_extensions():
         extra_compile_args["cxx"] += ["-DAT_PARALLEL_OPENMP"]
         extra_compile_args["cxx"] += ["-fopenmp"]
 
-        hipcc_flags = [
-            "-D__HIP_PLATFORM_AMD__",
-            "-DC10_CUDA_NO_CMAKE_CONFIGURE_FILE",
-            "-DUSE_ROCM",
-            f"--offload-arch={gpu_arch}",
-            "-DROCPRIM_TARGET_RDNA3=1",
-            "-DROCPRIM_WARP_SIZE_32=32",
-            "-DROCPRIM_WARP_SIZE_64=64",
-            "-DROCPRIM_MAX_WARP_SIZE=32",
-        ]
+        hipcc_flags = [ "-D__HIP_PLATFORM_AMD__", "-DC10_CUDA_NO_CMAKE_CONFIGURE_FILE", "-DUSE_ROCM" , f"--offload-arch={gpu_arch}"]
         if WITH_SYMBOLS:
-            hipcc_flags += ["-g", "-ggdb", "-O0"]
+            hipcc_flags += ["-g", "-ggdb" , "-O0"]
         else:
-            hipcc_flags += ["-O3"]
+            hipcc_flags += ["-O3" ]
         if LINE_INFO:
             hipcc_flags += ["-gline-tables-only"]
         if torch.version.hip:
@@ -241,16 +216,11 @@ def get_extensions():
             define_macros += [("USE_ROCM", "1")]
             undef_macros += ["__HIP_NO_HALF_CONVERSIONS__"]
         if ENABLE_TEST_COVERAGE:
-            extra_compile_args["cxx"] += [
-                "-fprofile-instr-generate",
-                "-fcoverage-mapping",
-                "-Qunused-arguments",
-                "--gcc-toolchain=/usr",
-            ]
-            hipcc_flags += ["-fprofile-instr-generate", "-fcoverage-mapping"]
-            extra_link_args += ["-fprofile-instr-generate"]
-
-        # Its still nvcc flags that are used for HIP compilation
+            extra_compile_args['cxx'] += ['-fprofile-instr-generate', '-fcoverage-mapping', '-Qunused-arguments', '--gcc-toolchain=/usr']
+            hipcc_flags += ['-fprofile-instr-generate', '-fcoverage-mapping']
+            extra_link_args += ['-fprofile-instr-generate']
+	
+	# Its still nvcc flags that are used for HIP compilation
         extra_compile_args["nvcc"] = hipcc_flags
         current_dir = pathlib.Path(__file__).parent.resolve()
 
@@ -270,10 +240,11 @@ def get_extensions():
             define_macros=define_macros,
             undef_macros=undef_macros,
             extra_compile_args=extra_compile_args,
-            extra_link_args=extra_link_args,
+            extra_link_args=extra_link_args
         )
         return [extension]
     else:
+
         from torch.__config__ import parallel_info
         from torch.utils.cpp_extension import CUDAExtension
 
@@ -344,9 +315,7 @@ def get_extensions():
         )
         return [extension]
 
-
 import torch.utils.cpp_extension as ce
-
 
 def fixed_get_compiler_abi_compatibility_and_version(compiler):
     try:
@@ -355,14 +324,9 @@ def fixed_get_compiler_abi_compatibility_and_version(compiler):
         # Fallback for clang++ "17.0git"
         return ("gcc", (17, 0))
 
-
 if not hasattr(ce, "original_get_compiler_abi_compatibility_and_version"):
-    ce.original_get_compiler_abi_compatibility_and_version = (
-        ce.get_compiler_abi_compatibility_and_version
-    )
-    ce.get_compiler_abi_compatibility_and_version = (
-        fixed_get_compiler_abi_compatibility_and_version
-    )
+    ce.original_get_compiler_abi_compatibility_and_version = ce.get_compiler_abi_compatibility_and_version
+    ce.get_compiler_abi_compatibility_and_version = fixed_get_compiler_abi_compatibility_and_version
 
 
 setup(
@@ -371,7 +335,7 @@ setup(
     description=" Python package for differentiable rasterization of gaussians",
     keywords="gaussian, splatting, cuda",
     url=URL,
-    author="AMD Corporation",
+	author="AMD Corporation",
     license="Apache 2.0",
     python_requires=">=3.7",
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -16,43 +16,43 @@ __version__ = None
 exec(open("gsplat/version.py", "r").read())
 import subprocess
 
+
 def get_rocm_arch():
     """
     Runs rocminfo and extracts the GPU architecture (gfx code).
-    
+
     Returns:
         str: The gfx code (e.g., 'gfx942', 'gfx90a'), or 'gfx942' as fallback.
     """
     try:
         # Run rocminfo command
         result = subprocess.run(
-            ['rocminfo'],
-            capture_output=True,
-            text=True,
-            check=True
+            ["rocminfo"], capture_output=True, text=True, check=True
         )
-        
+
         # Parse the output to find the gfx architecture
         # Look for lines like "Name:                    gfx942"
         output = result.stdout
-        
+
         # Search for gfx code pattern
-        match = re.search(r'Name:\s+(gfx[0-9a-z]+)', output)
+        match = re.search(r"Name:\s+(gfx[0-9a-z]+)", output)
         if match:
             gfx_code = match.group(1)
             print(f"Detected ROCm GPU architecture: {gfx_code}")
             return gfx_code
-        
+
         # Alternative pattern: sometimes it appears as "gfxXXX" directly
-        match = re.search(r'\b(gfx[0-9a-z]+)\b', output)
+        match = re.search(r"\b(gfx[0-9a-z]+)\b", output)
         if match:
             gfx_code = match.group(1)
             print(f"Detected ROCm GPU architecture: {gfx_code}")
             return gfx_code
-            
-        print("Warning: Could not detect GPU architecture from rocminfo, using default gfx942")
+
+        print(
+            "Warning: Could not detect GPU architecture from rocminfo, using default gfx942"
+        )
         return "gfx942"
-        
+
     except subprocess.CalledProcessError as e:
         print(f"Error running rocminfo: {e}")
         print("Using default architecture: gfx942")
@@ -65,6 +65,7 @@ def get_rocm_arch():
         print(f"Unexpected error getting ROCm architecture: {e}")
         print("Using default architecture: gfx942")
         return "gfx942"
+
 
 def is_git_repo(folder_path):
     """
@@ -83,10 +84,10 @@ def is_git_repo(folder_path):
     try:
         # Run the git command
         result = subprocess.run(
-            ['git', 'rev-parse', '--git-dir'],
+            ["git", "rev-parse", "--git-dir"],
             cwd=folder_path,
             capture_output=True,
-            text=True
+            text=True,
         )
 
         # The command returns an exit code of 0 if it's a repo
@@ -100,6 +101,7 @@ def is_git_repo(folder_path):
         # Handle other unexpected errors
         print(f"An unexpected error occurred: {e}")
         return False
+
 
 def get_git_rev(folder_path):
     """
@@ -117,15 +119,11 @@ def get_git_rev(folder_path):
         # Use subprocess to run 'git rev-parse main' to get the commit hash
         # 'rev-parse' is a low-level command used to translate a human-readable
         # name into an SHA-1.
-        command = ['git', 'rev-parse', '--short' ,"HEAD"]
+        command = ["git", "rev-parse", "--short", "HEAD"]
 
         # Run the command in the specified folder
         result = subprocess.run(
-            command,
-            cwd=folder_path,
-            capture_output=True,
-            text=True,
-            check=True
+            command, cwd=folder_path, capture_output=True, text=True, check=True
         )
 
         # The output is the commit hash
@@ -135,7 +133,9 @@ def get_git_rev(folder_path):
     except subprocess.CalledProcessError as e:
         # This error is raised if the command fails, which happens if 'main'
         # branch doesn't exist
-        print(f"Error: The #{branch_name} branch does not exist or another error occurred: {e}")
+        print(
+            f"Error: The #{branch_name} branch does not exist or another error occurred: {e}"
+        )
         return ""
     except FileNotFoundError:
         print("Error: Git is not installed or not in your system's PATH.")
@@ -144,6 +144,7 @@ def get_git_rev(folder_path):
         print(f"An unexpected error occurred: {e}")
         return ""
     return ""
+
 
 if is_git_repo:
     git_rev = get_git_rev(os.getcwd())
@@ -154,7 +155,7 @@ print(f"VERSION = {__version__}")
 URL = "https://github.com/rocm/gsplat"
 
 BUILD_NO_CUDA = os.getenv("BUILD_NO_CUDA", "0") == "1"
-WITH_SYMBOLS =  os.getenv("WITH_SYMBOLS", "0") == "1"
+WITH_SYMBOLS = os.getenv("WITH_SYMBOLS", "0") == "1"
 LINE_INFO = os.getenv("LINE_INFO", "0") == "1"
 
 ENABLE_TEST_COVERAGE = os.getenv("ENABLE_TEST_COVERAGE", "0") == "1"
@@ -166,16 +167,20 @@ if not MAX_JOBS:
     os.environ["MAX_JOBS"] = "10"
     print(f"Setting MAX_JOBS to {os.environ['MAX_JOBS']}")
 
+
 def get_ext():
     from torch.utils.cpp_extension import BuildExtension
+
     return BuildExtension.with_options(no_python_abi_suffix=True, use_ninja=True)
 
 
 def get_extensions():
     if IS_ROCM:
         from torch.utils.cpp_extension import CUDAExtension
+
         print("ROCM detected, compiling with HIP support...")
         from torch.utils.cpp_extension import CppExtension
+
         # Get the GPU architecture dynamically
         gpu_arch = get_rocm_arch()
         print(f"gpu arch is set to {gpu_arch}")
@@ -184,18 +189,29 @@ def get_extensions():
         conda_pip_packages = f"{conda_lib_path}/python3.11/site-packages"
 
         # Use relative path instead of hardcoded absolute path
-        extensions_dir = osp.join("gsplat","cuda")
-        sources = glob.glob(osp.join(extensions_dir, "csrc", "*.cu")) + glob.glob(osp.join(extensions_dir, "csrc", "*.cpp"))
+        extensions_dir = osp.join("gsplat", "cuda")
+        sources = glob.glob(osp.join(extensions_dir, "csrc", "*.cu")) + glob.glob(
+            osp.join(extensions_dir, "csrc", "*.cpp")
+        )
         sources += [osp.join(extensions_dir, "ext.cpp")]
 
         undef_macros = []
         define_macros = []
 
-        extra_compile_args = {"cxx": ["-D__HIP_PLATFORM_AMD__" , "-Wno-sign-compare", "-DC10_CUDA_NO_CMAKE_CONFIGURE_FILE", "-DUSE_ROCM"]}
+        extra_compile_args = {
+            "cxx": [
+                "-D__HIP_PLATFORM_AMD__",
+                "-Wno-sign-compare",
+                "-DC10_CUDA_NO_CMAKE_CONFIGURE_FILE",
+                "-DUSE_ROCM",
+            ]
+        }
         if WITH_SYMBOLS:
             extra_compile_args["cxx"] += ["-g", "-O0"]
         else:
-            extra_compile_args = {"cxx": ["-O3", "-Wno-attributes", "-Wno-switch", "-Wno-comment"]}
+            extra_compile_args = {
+                "cxx": ["-O3", "-Wno-attributes", "-Wno-switch", "-Wno-comment"]
+            }
 
         extra_link_args = ["-s"]
 
@@ -203,11 +219,20 @@ def get_extensions():
         extra_compile_args["cxx"] += ["-DAT_PARALLEL_OPENMP"]
         extra_compile_args["cxx"] += ["-fopenmp"]
 
-        hipcc_flags = [ "-D__HIP_PLATFORM_AMD__", "-DC10_CUDA_NO_CMAKE_CONFIGURE_FILE", "-DUSE_ROCM" , f"--offload-arch={gpu_arch}"]
+        hipcc_flags = [
+            "-D__HIP_PLATFORM_AMD__",
+            "-DC10_CUDA_NO_CMAKE_CONFIGURE_FILE",
+            "-DUSE_ROCM",
+            f"--offload-arch={gpu_arch}",
+            "-DROCPRIM_TARGET_RDNA3=1",
+            "-DROCPRIM_WARP_SIZE_32=32",
+            "-DROCPRIM_WARP_SIZE_64=64",
+            "-DROCPRIM_MAX_WARP_SIZE=32",
+        ]
         if WITH_SYMBOLS:
-            hipcc_flags += ["-g", "-ggdb" , "-O0"]
+            hipcc_flags += ["-g", "-ggdb", "-O0"]
         else:
-            hipcc_flags += ["-O3" ]
+            hipcc_flags += ["-O3"]
         if LINE_INFO:
             hipcc_flags += ["-gline-tables-only"]
         if torch.version.hip:
@@ -216,11 +241,16 @@ def get_extensions():
             define_macros += [("USE_ROCM", "1")]
             undef_macros += ["__HIP_NO_HALF_CONVERSIONS__"]
         if ENABLE_TEST_COVERAGE:
-            extra_compile_args['cxx'] += ['-fprofile-instr-generate', '-fcoverage-mapping', '-Qunused-arguments', '--gcc-toolchain=/usr']
-            hipcc_flags += ['-fprofile-instr-generate', '-fcoverage-mapping']
-            extra_link_args += ['-fprofile-instr-generate']
-	
-	# Its still nvcc flags that are used for HIP compilation
+            extra_compile_args["cxx"] += [
+                "-fprofile-instr-generate",
+                "-fcoverage-mapping",
+                "-Qunused-arguments",
+                "--gcc-toolchain=/usr",
+            ]
+            hipcc_flags += ["-fprofile-instr-generate", "-fcoverage-mapping"]
+            extra_link_args += ["-fprofile-instr-generate"]
+
+        # Its still nvcc flags that are used for HIP compilation
         extra_compile_args["nvcc"] = hipcc_flags
         current_dir = pathlib.Path(__file__).parent.resolve()
 
@@ -240,11 +270,10 @@ def get_extensions():
             define_macros=define_macros,
             undef_macros=undef_macros,
             extra_compile_args=extra_compile_args,
-            extra_link_args=extra_link_args
+            extra_link_args=extra_link_args,
         )
         return [extension]
     else:
-
         from torch.__config__ import parallel_info
         from torch.utils.cpp_extension import CUDAExtension
 
@@ -315,7 +344,9 @@ def get_extensions():
         )
         return [extension]
 
+
 import torch.utils.cpp_extension as ce
+
 
 def fixed_get_compiler_abi_compatibility_and_version(compiler):
     try:
@@ -324,9 +355,14 @@ def fixed_get_compiler_abi_compatibility_and_version(compiler):
         # Fallback for clang++ "17.0git"
         return ("gcc", (17, 0))
 
+
 if not hasattr(ce, "original_get_compiler_abi_compatibility_and_version"):
-    ce.original_get_compiler_abi_compatibility_and_version = ce.get_compiler_abi_compatibility_and_version
-    ce.get_compiler_abi_compatibility_and_version = fixed_get_compiler_abi_compatibility_and_version
+    ce.original_get_compiler_abi_compatibility_and_version = (
+        ce.get_compiler_abi_compatibility_and_version
+    )
+    ce.get_compiler_abi_compatibility_and_version = (
+        fixed_get_compiler_abi_compatibility_and_version
+    )
 
 
 setup(
@@ -335,7 +371,7 @@ setup(
     description=" Python package for differentiable rasterization of gaussians",
     keywords="gaussian, splatting, cuda",
     url=URL,
-	author="AMD Corporation",
+    author="AMD Corporation",
     license="Apache 2.0",
     python_requires=">=3.7",
     install_requires=[

--- a/tests/test_wave32_gradients.py
+++ b/tests/test_wave32_gradients.py
@@ -1,0 +1,293 @@
+"""
+Finite difference gradient check for wave32 (RDNA3) backward kernels.
+
+Compares the analytical gradients from the CUDA backward pass against
+numerical (finite difference) gradients.
+
+Usage:
+    python3 tests/test_wave32_gradients.py
+"""
+
+import torch
+import math
+
+device = torch.device("cuda:0")
+
+
+def create_scene(N=20, width=32, height=32, focal=50.0, seed=42):
+    """Create a simple scene with gaussians in front of the camera."""
+    torch.manual_seed(seed)
+
+    means = torch.zeros((N, 3), device=device)
+    means[:, 0] = (torch.rand(N, device=device) - 0.5) * 2.0
+    means[:, 1] = (torch.rand(N, device=device) - 0.5) * 2.0
+    means[:, 2] = 2.0 + torch.rand(N, device=device) * 2.0
+
+    quats = torch.randn((N, 4), device=device)
+    quats = quats / quats.norm(dim=-1, keepdim=True)
+    scales = torch.rand((N, 3), device=device) * 0.2 + 0.05
+    opacities = torch.rand((N,), device=device) * 0.3 + 0.7
+    colors = torch.rand((N, 3), device=device)
+
+    viewmats = torch.eye(4, device=device)[None, :, :]
+    Ks = torch.tensor(
+        [[focal, 0.0, width / 2.0], [0.0, focal, height / 2.0], [0.0, 0.0, 1.0]],
+        device=device,
+    )[None, :, :]
+
+    return means, quats, scales, opacities, colors, viewmats, Ks, width, height
+
+
+def do_rasterization(
+    means, quats, scales, opacities, colors, viewmats, Ks, width, height, tile_size=16
+):
+    from gsplat.rendering import rasterization
+
+    return rasterization(
+        means=means,
+        quats=quats,
+        scales=scales,
+        opacities=opacities,
+        colors=colors,
+        viewmats=viewmats,
+        Ks=Ks,
+        width=width,
+        height=height,
+        tile_size=tile_size,
+        packed=False,
+    )
+
+
+def finite_diff_check(param_name, param, all_params, eps=5e-4, max_elements=20):
+    """
+    Compare analytical gradient vs finite difference gradient.
+    Returns max relative error and status.
+    """
+    from gsplat.rendering import rasterization
+
+    means, quats, scales, opacities, colors, viewmats, Ks, width, height = all_params
+
+    # Compute analytical gradient
+    kw = dict(
+        quats=quats,
+        scales=scales,
+        opacities=opacities,
+        colors=colors,
+        viewmats=viewmats,
+        Ks=Ks,
+        width=width,
+        height=height,
+        tile_size=16,
+        packed=False,
+    )
+
+    if param_name == "colors":
+        colors_req = param.clone().detach().requires_grad_(True)
+        kw["colors"] = colors_req
+        kw.pop("opacities", None)
+        r, a, m = rasterization(means=means, opacities=opacities, **kw)
+        loss = r.sum()
+        loss.backward()
+        analytical_grad = colors_req.grad.clone()
+    elif param_name == "opacities":
+        opac_req = param.clone().detach().requires_grad_(True)
+        kw["opacities"] = opac_req
+        r, a, m = rasterization(means=means, **kw)
+        loss = r.sum()
+        loss.backward()
+        analytical_grad = opac_req.grad.clone()
+    elif param_name == "means":
+        means_req = param.clone().detach().requires_grad_(True)
+        r, a, m = rasterization(means=means_req, **kw)
+        loss = r.sum()
+        loss.backward()
+        analytical_grad = means_req.grad.clone()
+    else:
+        raise ValueError(f"Unknown param: {param_name}")
+
+    # Compute finite difference gradient for a subset of elements
+    flat_param = param.detach().clone().flatten()
+    n_check = min(max_elements, flat_param.numel())
+
+    indices = torch.linspace(0, flat_param.numel() - 1, n_check).long()
+
+    errors = []
+
+    for idx in indices:
+        idx = idx.item()
+        orig = flat_param[idx].item()
+
+        # f(x + eps)
+        flat_param[idx] = orig + eps
+        perturbed = flat_param.reshape(param.shape)
+        r_p, _, _ = do_rasterization(
+            means if param_name != "means" else perturbed,
+            quats,
+            scales,
+            opacities if param_name != "opacities" else perturbed,
+            colors if param_name != "colors" else perturbed,
+            viewmats,
+            Ks,
+            width,
+            height,
+        )
+        loss_plus = r_p.sum()
+
+        # f(x - eps)
+        flat_param[idx] = orig - eps
+        perturbed = flat_param.reshape(param.shape)
+        r_m, _, _ = do_rasterization(
+            means if param_name != "means" else perturbed,
+            quats,
+            scales,
+            opacities if param_name != "opacities" else perturbed,
+            colors if param_name != "colors" else perturbed,
+            viewmats,
+            Ks,
+            width,
+            height,
+        )
+        loss_minus = r_m.sum()
+
+        # Restore
+        flat_param[idx] = orig
+
+        fd = (loss_plus - loss_minus).item() / (2 * eps)
+        ana = analytical_grad.flatten()[idx].item()
+
+        if abs(fd) > 1e-6 or abs(ana) > 1e-6:
+            denom = max(abs(fd), abs(ana))
+            rel_err = abs(fd - ana) / denom
+            errors.append((rel_err, idx, fd, ana))
+
+    if not errors:
+        return 0.0, 0, "NO NON-ZERO GRADIENTS"
+
+    max_err = max(e[0] for e in errors)
+    mean_err = sum(e[0] for e in errors) / len(errors)
+
+    # Print worst mismatches
+    errors.sort(key=lambda x: -x[0])
+    print(f"  Top 5 worst elements:")
+    for rel_err, idx, fd, ana in errors[:5]:
+        print(f"    idx={idx}: fd={fd:.6f}, ana={ana:.6f}, rel_err={rel_err:.6f}")
+
+    status = "FAIL" if max_err > 0.1 else "PASS"
+    if max_err < 0.01:
+        status = "PASS (excellent)"
+    elif max_err < 0.05:
+        status = "PASS (good)"
+
+    return max_err, len(errors), status
+
+
+def main():
+    from gsplat.rendering import rasterization
+
+    print("=" * 70)
+    print("WAVE32 GRADIENT VALIDATION TEST")
+    print("=" * 70)
+    print(f"Device: {torch.cuda.get_device_name(0)}")
+    print(f"Warp size: {torch.cuda.get_device_properties(0).warp_size}")
+    print()
+
+    scene = create_scene(N=20, width=32, height=32, focal=50.0, seed=42)
+    means, quats, scales, opacities, colors, viewmats, Ks, width, height = scene
+
+    all_passed = True
+
+    for param_name, param in [
+        ("colors", colors),
+        ("opacities", opacities),
+        ("means", means),
+    ]:
+        print(f"--- {param_name} gradient check (tile_size=16) ---")
+        max_err, n_checked, status = finite_diff_check(
+            param_name,
+            param,
+            scene,
+            eps=5e-4,
+            max_elements=20,
+        )
+        print(f"  Elements checked: {n_checked}")
+        print(f"  Max relative error: {max_err:.6f}")
+        print(f"  Status: {status}")
+        print()
+        if "FAIL" in status:
+            all_passed = False
+
+    # Test tile_size=8 (triggers bs64 kernel path)
+    print("--- tile_size=8 test (bs64 kernel) ---")
+    scene8 = create_scene(N=20, width=16, height=16, focal=30.0, seed=99)
+    m8, q8, s8, o8, c8, v8, k8, w8, h8 = scene8
+    try:
+        m = m8.clone().requires_grad_(True)
+        c = c8.clone().requires_grad_(True)
+        o = o8.clone().requires_grad_(True)
+        r, a, meta = do_rasterization(m, q8, s8, o, c, v8, k8, w8, h8, tile_size=8)
+        loss = r.sum()
+        loss.backward()
+        has_nan_m = torch.isnan(m.grad).any().item()
+        has_nan_c = torch.isnan(c.grad).any().item()
+        has_nan_o = torch.isnan(o.grad).any().item()
+        print(
+            f"  render_sum={r.sum():.4f}, alpha_coverage={((a > 0.01).float().mean().item()):.2%}"
+        )
+        print(
+            f"  grad NaN: means={has_nan_m}, colors={has_nan_c}, opacities={has_nan_o}"
+        )
+        if has_nan_m or has_nan_c or has_nan_o:
+            all_passed = False
+            print("  Status: FAIL (NaN in gradients)")
+        else:
+            print("  Status: PASS (no NaN)")
+    except Exception as e:
+        print(f"  ERROR: {e}")
+        all_passed = False
+    print()
+
+    # Gradient consistency (two runs should be identical)
+    print("--- Gradient consistency (determinism) ---")
+    grads_runs = []
+    for run in range(2):
+        m = means.clone().requires_grad_(True)
+        c = colors.clone().requires_grad_(True)
+        o = opacities.clone().requires_grad_(True)
+        r, a, meta = do_rasterization(
+            m, quats, scales, o, c, viewmats, Ks, width, height
+        )
+        loss = r.sum()
+        loss.backward()
+        grads_runs.append(
+            {
+                "means": m.grad.clone(),
+                "colors": c.grad.clone(),
+                "opacities": o.grad.clone(),
+            }
+        )
+
+    for name in ["means", "colors", "opacities"]:
+        diff = (grads_runs[0][name] - grads_runs[1][name]).abs().max().item()
+        # atomicAdd accumulation order is non-deterministic; float32 addition
+        # is not associative, so ULP-level differences (~1e-5) are expected.
+        status = "PASS" if diff < 1e-4 else "FAIL"
+        if diff >= 1e-4:
+            all_passed = False
+        print(f"  {name}: max diff = {diff:.10f} [{status}]")
+
+    print()
+    print("=" * 70)
+    if all_passed:
+        print("ALL TESTS PASSED")
+    else:
+        print("SOME TESTS FAILED - gradients may be incorrect!")
+    print("=" * 70)
+
+    return all_passed
+
+
+if __name__ == "__main__":
+    import sys
+
+    passed = main()
+    sys.exit(0 if passed else 1)


### PR DESCRIPTION
Not a real pull request, as the code is not production quality / it makes it incompatible with wave64 cards.

But this branch let´s you build it against ROCM 7.2 and works on RNDA consumer cards aka 32 wide waves instead of 64.

Downside: It adapts the original algorithm but needs to use Shared Memory now to combine the results of two warps when processing 8x8 blocks, as we no longer have the perfect 64 pixels to 64 warps match ..

Just opened it so if someone stumples upon the same problem, it already works :)

using it in nerfstudio with splatfacto and it works. This is from my gfx1101 (Navi 32 based rdna 3 card named 7800 XT):
<img width="2074" height="1154" alt="image" src="https://github.com/user-attachments/assets/8f5efd06-449e-46a7-bdf8-058ef157e84c" />
