### PR TITLE
Update checkout command to use release branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,12 +89,12 @@ We provide a set of examples to get you started.
    cd gsplat
    git sparse-checkout init --cone
    git sparse-checkout add examples
-   git checkout main
    ```
 
 2. Install dependencies and download datasets:
 
    ```bash
+   git checkout release/1.5.3b2
    cd examples
    ./install_dependencies.sh
    python datasets/download_dataset.py


### PR DESCRIPTION
install_dependencies.sh exists in the release/1.5.3b2 branch not main

## Motivation

install_dependencies.sh doesn't exist in main, theirs has requirements.txt and requires the user to pip install -r requirements.txt rather than executing this script. ROCm install differs from the modern NVIDIA install

Furthermore, release/1.5.3b2's main/examples is 552 commits ahead of main

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

./install_dependencies.sh fails because the file doesn't exist. 
If you instead use pip install -r requirements.txt that main assumes, you get an incorrect installation as release/1.5.3b2 includes: 
pip install git+https://github.com/rahul-goel/fused-ssim/@88169c51c22973ad8fd2429c3298d8356fdd5dc8 --no-build-isolation

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
